### PR TITLE
reproducing - fixing the Pytorch version and documenting env setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 data/SPNLG
 data/Wiki
+exp/
+env/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Details info: [HERE](./data/README.md)
 # dataset Wiki or SPNLG
 export dataset=Wiki; \
 export stamp="$(date +%Y%m%d_%H%M%S)"; d="exp/$dataset.$stamp"; mkdir -p $d; \
-cmd="python train.py -data data/$dataset -max_vocab_cnt 50000 -emb_size 786 -hid_size 512 -table_hid_size 256 -pool_type max -sent_represent last_hid -z_latent_size 128 -c_latent_size 256 -dec_attention -drop_emb -add_preserving_content_loss -pc_weight 1.0 -add_preserving_template_loss -pt_weight 1.0 -anneal_function_z const -anneal_k_z 0.8 -anneal_function_c const -anneal_k_c 0.8 -add_mi_z -mi_z_weight 0.5 -add_mi_c -mi_c_weight 0.5 -lr 0.001 -clip 5.0 -log_interval 500 -bsz 16 -paired_epochs 5 -raw_epochs 2 -epochs 20 -cuda -save $d/model.ckpt"; echo "$cmd" > $d/cmd; \
+cmd="time python train.py -data data/$dataset -max_vocab_cnt 50000 -emb_size 786 -hid_size 512 -table_hid_size 256 -pool_type max -sent_represent last_hid -z_latent_size 128 -c_latent_size 256 -dec_attention -drop_emb -add_preserving_content_loss -pc_weight 1.0 -add_preserving_template_loss -pt_weight 1.0 -anneal_function_z const -anneal_k_z 0.8 -anneal_function_c const -anneal_k_c 0.8 -add_mi_z -mi_z_weight 0.5 -add_mi_c -mi_c_weight 0.5 -lr 0.001 -clip 5.0 -log_interval 500 -bsz 16 -paired_epochs 5 -raw_epochs 2 -epochs 20 -cuda -save $d/model.ckpt"; echo "$cmd" > $d/cmd; \
 $cmd 2>&1 | tee $d/log
 ```
 Notice that the arguments may be different.

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Details info: [HERE](./data/README.md)
 - **Training**:
 
 ```
-DATASET_PATH=<path_to_dataset>
-MODEL_PATH=<path_to_model>
-
-python train.py -data ${DATASET_PATH} -max_vocab_cnt 50000 -emb_size 786 -hid_size 512 -table_hid_size 256 -pool_type max -sent_represent last_hid -z_latent_size 128 -c_latent_size 256 -dec_attention -drop_emb -add_preserving_content_loss -pc_weight 1.0 -add_preserving_template_loss -pt_weight 1.0 -anneal_function_z const -anneal_k_z 0.8 -anneal_function_c const -anneal_k_c 0.8 -add_mi_z -mi_z_weight 0.5 -add_mi_c -mi_c_weight 0.5 -lr 0.001 -clip 5.0 -cuda -log_interval 500 -bsz 16 -paired_epochs 5 -raw_epochs 2 -epochs 20 -cuda -save ${MODEL_PATH}
+# dataset Wiki or SPNLG
+export dataset=Wiki; \
+export stamp="$(date +%Y%m%d_%H%M%S)"; d="exp/$dataset.$stamp"; mkdir -p $d; \
+cmd="python train.py -data data/$dataset -max_vocab_cnt 50000 -emb_size 786 -hid_size 512 -table_hid_size 256 -pool_type max -sent_represent last_hid -z_latent_size 128 -c_latent_size 256 -dec_attention -drop_emb -add_preserving_content_loss -pc_weight 1.0 -add_preserving_template_loss -pt_weight 1.0 -anneal_function_z const -anneal_k_z 0.8 -anneal_function_c const -anneal_k_c 0.8 -add_mi_z -mi_z_weight 0.5 -add_mi_c -mi_c_weight 0.5 -lr 0.001 -clip 5.0 -log_interval 500 -bsz 16 -paired_epochs 5 -raw_epochs 2 -epochs 20 -cuda -save $d/model.ckpt"; echo "$cmd" > $d/cmd; \
+$cmd 2>&1 | tee $d/log
 ```
 Notice that the arguments may be different.
 - **Generation**:

--- a/data_utils/hyps2tabgenie_htmlulli.py
+++ b/data_utils/hyps2tabgenie_htmlulli.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+import sys
+
+hyp_file = sys.argv[1]
+
+with open(hyp_file, "rt") as r:
+    egs = r.read().split("\n\n")
+    egs_hyps = [e.split("\n") for e in egs]
+
+for eh in egs_hyps:
+    hyp_html = " ".join([f"<li>{h}</li>" for h in eh])
+    print(f"<ul>{hyp_html}</ul>")

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+name: moosenet
+channels:
+  - pytorch
+  - defaults
+  - conda-forge
+dependencies:
+  - python=3.6
+  # - cudatoolkit=11.3
+  - pytorch=1.1.0
+  - pip
+  - pip:
+  #   # - torchvision
+    - numpy
+    - nltk

--- a/generate.sh
+++ b/generate.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -eo pipefail
+set -x 
+# conda activate ./env
+ckpt_path=$1;shift
+export dataset=Wiki
+export stamp="$(date +%Y%m%d_%H%M%S)"
+d="$(dirname $ckpt_path)/generate"  # output_dir
+output_path="$d/generate.txt"
+cuda=""  # leave empty or provide -cuda
+mkdir -p $d
+# sample top 5 with temp_sample decode method
+# cmd="time python generate.py -data data/$dataset -max_vocab_cnt 50000 -load $ckpt_path -various_gen 5 -mask_prob 0.0 $cuda -decode_method temp_sample -sample_temperature 0.2 -gen_to_fi $output_path"
+cmd="time python generate.py -data data/$dataset -max_vocab_cnt 50000 -load $ckpt_path -various_gen 1 -mask_prob 0.0 $cuda -decode_method beam_search -sample_temperature 0.2 -gen_to_fi $output_path"
+echo "$cmd" > $d/cmd
+echo "Saving log and model to $d"
+$cmd 2>&1 | tee $d/log

--- a/train.sh
+++ b/train.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+conda activate ./env
+export dataset=Wiki
+export stamp="$(date +%Y%m%d_%H%M%S)"
+d="exp/$dataset.$stamp"
+mkdir -p $d
+cuda=""  # leave empty or provide -cuda
+cmd="python train.py $cuda -data data/$dataset -max_vocab_cnt 50000 -emb_size 786 -hid_size 512 -table_hid_size 256 -pool_type max -sent_represent last_hid -z_latent_size 128 -c_latent_size 256 -dec_attention -drop_emb -add_preserving_content_loss -pc_weight 1.0 -add_preserving_template_loss -pt_weight 1.0 -anneal_function_z const -anneal_k_z 0.8 -anneal_function_c const -anneal_k_c 0.8 -add_mi_z -mi_z_weight 0.5 -add_mi_c -mi_c_weight 0.5 -lr 0.001 -clip 5.0 -log_interval 500 -bsz 16 -paired_epochs 5 -raw_epochs 2 -epochs 20 -save $d/model.ckpt"
+echo "$cmd" > $d/cmd
+echo "Saving log and model to $d"
+$cmd 2>&1 | tee $d/log


### PR DESCRIPTION
Running on UFAL cluster

CPU command
```
No CUDA device.
data loaded!
total vocabulary size: 50007
Num of parameters in vae model: 115.50 M. 
batch 500/5260 | train pair_nll 4.40067 | train pair_KLz 0.160155 | train kl_weight_z 0.8 | train pair_mse 1.0203 | train pair_KLc 0.319848 | train pt_loss 2.10627 | train pair_mi_z 0.115098 | train pair_mi_c 0.599773 | train pair_loss 8.26868
```

GPU command fails.
```
Num of parameters in vae model: 115.50 M.                                                                                                                                                                           
Traceback (most recent call last):                                                                                                                                                                                  
  File "train.py", line 510, in <module>                                                                                                                                                                            
    train_pair(epoch)                                                                                                                                                                                               
  File "train.py", line 240, in train_pair                                                                                                                                                                          
    Variable(sentence_mask), valid=False)                                                                                                                                                                           
  File "/lnet/work/people/oplatek/VariationalTemplateMachine/models/variational_template_machine.py", line 307, in decode_pair                                                                                                                                                                                                                                                                                                           
    y_out, h_yt = self.rnn_encode(sent_emb, h_y0)  # y_out: seq x b x layer*hid, h_yt: layer x b x hid                                                                                                              
  File "/lnet/work/people/oplatek/VariationalTemplateMachine/env/lib/python3.6/site-packages/torch/nn/modules/module.py", line 493, in __call__                                                                                                                                                                                                                                                                                          
    result = self.forward(*input, **kwargs)                                                               
  File "/lnet/work/people/oplatek/VariationalTemplateMachine/env/lib/python3.6/site-packages/torch/nn/modules/rnn.py", line 211, in forward                                                                                                                                                                                                                                                                                              
    self.dropout, self.training, self.bidirectional, self.batch_first)                                                                                                                                                                                                                                                                                                                                                                   
RuntimeError: cuDNN error: CUDNN_STATUS_EXECUTION_FAILED 
```

TODOs:
- [ ] use the trained model for generating